### PR TITLE
Custom Interval Selection

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -3,8 +3,7 @@ $(document).ready(function () {
     $('.tabs').tabs();
     $('.collapsible').collapsible({ accordion : false });
 
-    const TIME_INTERVAL = 15000; // 15 Seconds for testing purposes
-
+    let TIME_INTERVAL = localStorage.getItem("TIME_INTERVAL") || 2700000 // Defaults to 45 minutes if not previously set
 
     var audioElement = $('#audioSource')[0]; // jQuery syntax to grab the first child of the audio object
 
@@ -46,5 +45,24 @@ $(document).ready(function () {
         } else {
             audioElement.muted = false;
         }
+    });
+
+    $("#advancedSettingsForm").submit(function (event) {
+
+        let radioCheck = $('input[name=intervalGroup]:checked', '#advancedSettingsForm').val();
+        if (radioCheck == 'custom') {
+            let customValue = $('#customIntervalValue').val();
+            if (customValue < 1 || customValue > 120) {
+                event.preventDefault();
+                console.error("Custom intervals must be between 1 and 120 minutes.");
+            } else {
+                TIME_INTERVAL = customValue * 60 * 1000;
+                localStorage.setItem("TIME_INTERVAL", TIME_INTERVAL)
+            }
+        } else {
+            TIME_INTERVAL = radioCheck * 60 * 1000;
+            localStorage.setItem("TIME_INTERVAL", TIME_INTERVAL)
+        }
+
     });
 });

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -4,6 +4,7 @@ $(document).ready(function () {
     $('.collapsible').collapsible({ accordion : false });
 
     let TIME_INTERVAL = localStorage.getItem("TIME_INTERVAL") || 2700000 // Defaults to 45 minutes if not previously set
+    let activeInterval = false;
 
     var audioElement = $('#audioSource')[0]; // jQuery syntax to grab the first child of the audio object
 
@@ -12,11 +13,19 @@ $(document).ready(function () {
         audioElement.autoplay = true;
         audioElement.play();
 
-        // Makes an API request for a new song every TIME_INTERVAL milliseconds
-        setInterval(function () {
+        // If the interval is already determined, do not set another one
+        if(!active) {
+            timeout();
+        }
+    });
+
+    // Makes an API request for a new song every TIME_INTERVAL milliseconds
+    let timeout = () => {
+        activeInterval = true;
+        setTimeout(function () {
             loopPlayer(audioElement);
         }, TIME_INTERVAL);
-    });
+    }
 
     function loopPlayer(audioElement) {
         $.ajax({
@@ -33,6 +42,7 @@ $(document).ready(function () {
         setTimeout(function () {
             audioElement.play();
         }, 1500);
+        timeout();
     }
 
     $('#pause').click(function () {
@@ -48,6 +58,7 @@ $(document).ready(function () {
     });
 
     $("#advancedSettingsForm").submit(function (event) {
+        event.preventDefault();
 
         let radioCheck = $('input[name=intervalGroup]:checked', '#advancedSettingsForm').val();
         if (radioCheck == 'custom') {

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -1,7 +1,7 @@
 $(document).ready(function () {
     $('.sidenav').sidenav();
     $('.tabs').tabs();
-    $('.collapsible').collapsible({ accordion : false });
+    $('.collapsible').collapsible();
 
     let TIME_INTERVAL = localStorage.getItem("TIME_INTERVAL") || 2700000 // Defaults to 45 minutes if not previously set
     let activeInterval = false;

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -1,6 +1,7 @@
 $(document).ready(function () {
     $('.sidenav').sidenav();
     $('.tabs').tabs();
+    $('.collapsible').collapsible({ accordion : false });
 
     const TIME_INTERVAL = 15000; // 15 Seconds for testing purposes
 

--- a/public/stylesheets/components/_variables.scss
+++ b/public/stylesheets/components/_variables.scss
@@ -118,8 +118,8 @@ $carousel-item-width: $carousel-item-height !default;
 
 $collapsible-height: 3rem !default;
 $collapsible-line-height: $collapsible-height !default;
-$collapsible-header-color: #fff !default;
-$collapsible-border-color: #ddd !default;
+$collapsible-header-color: #242424 !default;
+$collapsible-border-color: #242424 !default;
 
 
 // 7. Chips
@@ -169,7 +169,7 @@ $input-border: 1px solid $input-border-color !default;
 $input-background: #fff !default;
 $input-error-color: $error-color !default;
 $input-success-color: $success-color !default;
-$input-focus-color: $secondary-color !default;
+$input-focus-color: #00b0ff !default;
 $input-font-size: 16px !default;
 $input-margin-bottom: 8px;
 $input-margin: 0 0 $input-margin-bottom 0 !default;
@@ -180,10 +180,10 @@ $input-disabled-solid-color: #949494 !default;
 $input-disabled-border: 1px dotted $input-disabled-color !default;
 $input-invalid-border: 1px solid $input-error-color !default;
 $input-icon-size: 2rem;
-$placeholder-text-color: lighten($input-border-color, 20%) !default;
+$placeholder-text-color: #bdbdbd !default;
 
 // Radio Buttons
-$radio-fill-color: $secondary-color !default;
+$radio-fill-color: #00b0ff !default;
 $radio-empty-color: #5a5a5a !default;
 $radio-border: 2px solid $radio-fill-color !default;
 

--- a/public/stylesheets/components/_variables.scss
+++ b/public/stylesheets/components/_variables.scss
@@ -180,7 +180,7 @@ $input-disabled-solid-color: #949494 !default;
 $input-disabled-border: 1px dotted $input-disabled-color !default;
 $input-invalid-border: 1px solid $input-error-color !default;
 $input-icon-size: 2rem;
-$placeholder-text-color: #bdbdbd !default;
+$placeholder-text-color: #424242 !default;
 
 // Radio Buttons
 $radio-fill-color: #00b0ff !default;

--- a/public/stylesheets/style.sass
+++ b/public/stylesheets/style.sass
@@ -55,7 +55,7 @@ nav.nav-center
   padding-top: 25px
 
 .content-container
-  width: 75%
+  width: 65%
   margin: auto
   text-align: left
 
@@ -70,3 +70,20 @@ nav.nav-center
   display: flex
   justify-content: center
   align-items: center
+
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-inner-spin-button
+  -webkit-appearance: none
+  margin: 0
+
+.intervalForm
+  line-height: 40px
+
+#customIntervalValue
+  width: 100px
+  height: 40px
+  background-color: #242424
+  color: #bdbdbd
+  margin-left: 5px
+  text-align: center
+  

--- a/views/index.pug
+++ b/views/index.pug
@@ -1,6 +1,5 @@
 extends layout
 
-
 block content
   header
     nav(class='nav-extended grey darken-4 nav-center')
@@ -35,20 +34,20 @@ block content
         audio(id='audioSource')
           source(type='audio/mp3' src=link)
 
-
     div(id='getting-started', class='col s12')
       div(class='content-container')
         h3 Getting Started
         p Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum dolorem similique eligendi. Rerum sit, cumque recusandae, sint libero aut iure ea blanditiis debitis labore animi temporibus dicta, iste commodi! Iusto, id! Sit fugiat corporis perferendis minima illo earum quos quas? Laboriosam repellendus magnam iste perspiciatis unde quia vel eveniet nobis?
 
-
     div(id='advanced-settings', class='col s12')
       h3 Advanced Settings
       div(class='content-container intervalForm')
         form(id='advancedSettingsForm', action='#')
-          ul(class="collapsible", data-collapsible="expandable")
-            li
-              div(class="collapsible-header" active) Intervals
+          ul(class="collapsible", data-collapsible="accordion")
+            li(class="active")
+              div(class="collapsible-header")
+                i(class="small material-icons") access_time
+                | Intervals
               div(class="collapsible-body")
                 p
                   label(for="shortInterval")
@@ -93,3 +92,4 @@ block content
 
   script(src='/javascripts/bin/materialize.min.js')
   script(src='/javascripts/main.js')
+  

--- a/views/index.pug
+++ b/views/index.pug
@@ -43,9 +43,31 @@ block content
 
 
     div(id='advanced-settings', class='col s12')
-      div(class='content-container')
-        h3 Advanced Settings
-        p Lorem ipsum, dolor sit amet consectetur adipisicing elit. Dolorem ullam dicta distinctio error, hic iusto molestias doloribus officia, eaque ut, non ipsam impedit. Cupiditate, necessitatibus.
+      h3 Advanced Settings
+      div(class='content-container intervalForm')
+        form(action='#')
+          ul(class="collapsible", data-collapsible="expandable")
+            li
+              div(class="collapsible-header" active) Intervals
+              div(class="collapsible-body")
+                p
+                  label(for="shortInterval")
+                    input(name="intervalGroup", type="radio", id="shortInterval")
+                    span Short Intervals (15 Minutes)
+                p
+                  label(for='mediumInterval')
+                    input(name="intervalGroup", type="radio", id="mediumInterval")
+                    span Medium Intervals (30 Minutes)
+                p
+                  label(for='longInterval')
+                    input(name="intervalGroup", type="radio", id="longInterval" checked)
+                    span Long Intervals (45 Minutes)
+                p
+                  label(for='customInterval')
+                    input(name="intervalGroup", type="radio", id="customInterval")
+                    span Custom Interval 
+                      input(placeholder="# of Minutes", id="customIntervalValue", type="number", min="1", max="120")
+          button(class='btn-large waves-effect waves-light light-blue accent-3', type="submit", name="settingsSubmit") Submit
 
   footer(class='page-footer')
     div(class='container')

--- a/views/index.pug
+++ b/views/index.pug
@@ -45,26 +45,26 @@ block content
     div(id='advanced-settings', class='col s12')
       h3 Advanced Settings
       div(class='content-container intervalForm')
-        form(action='#')
+        form(id='advancedSettingsForm', action='#')
           ul(class="collapsible", data-collapsible="expandable")
             li
               div(class="collapsible-header" active) Intervals
               div(class="collapsible-body")
                 p
                   label(for="shortInterval")
-                    input(name="intervalGroup", type="radio", id="shortInterval")
+                    input(name="intervalGroup", type="radio", id="shortInterval", value='15')
                     span Short Intervals (15 Minutes)
                 p
                   label(for='mediumInterval')
-                    input(name="intervalGroup", type="radio", id="mediumInterval")
+                    input(name="intervalGroup", type="radio", id="mediumInterval", value='30')
                     span Medium Intervals (30 Minutes)
                 p
                   label(for='longInterval')
-                    input(name="intervalGroup", type="radio", id="longInterval" checked)
+                    input(name="intervalGroup", type="radio", id="longInterval", value='45' checked)
                     span Long Intervals (45 Minutes)
                 p
                   label(for='customInterval')
-                    input(name="intervalGroup", type="radio", id="customInterval")
+                    input(name="intervalGroup", type="radio", id="customInterval", value='custom')
                     span Custom Interval 
                       input(placeholder="# of Minutes", id="customIntervalValue", type="number", min="1", max="120")
           button(class='btn-large waves-effect waves-light light-blue accent-3', type="submit", name="settingsSubmit") Submit


### PR DESCRIPTION
Closes #31 

Allows users to select custom intervals or select from a predetermined set. Intervals are set using `localStorage` to allow for continuity across sessions.

Still could use a bit of work. The form currently doesn't show what the users current interval is.